### PR TITLE
Style preview and colorize errors, inputs, and results

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,5 +1,109 @@
 @import 'bower_components/bootstrap-sass/assets/stylesheets/_bootstrap.scss';
-textarea.large {
-  width: 350px;
-  height: 250px;
+$dark-brown: #6A4E4A;
+$pale-orange: #F07A52;
+$light-light-orange: #FFDBB5;
+$red-fail: #F85F62;
+$red-fail-border: #AE3332;
+
+html, body {
+  min-height: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+.welcome {
+  position: absolute;
+  height: 150px;
+  width: 100%;
+  padding: 30px;
+  background-color: $pale-orange;
+  color: white;
+  font-family: ‘Courier New’, Courier, monospace;
+  margin-top: -150px;
+}
+
+.wrapper {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  height: 100%;
+  padding: 150px 0 100px;
+}
+
+.footer {
+  margin-bottom: -100px;
+  background-color: #DDD;
+  width: 100%;
+  height: 100px;
+  font-size: 15px;
+  text-align: center;
+  line-height: 100px;
+
+  a {
+    color: black;
+    text-decoration: none;
+    &:hover, &:active {
+      color: $pale-orange;
+    }
+  }
+}
+
+.emblem-preview {
+  min-height: 100%;
+  padding: 30px;
+}
+
+.input {
+  height: 500px;
+  width: 100%;
+  border: 1px solid $dark-brown;
+  border-radius: 2px;
+  margin: 30px 0;
+
+  textarea.large {
+    width: 100%;
+    height: 100%;
+    padding: 5px;
+  }
+
+  input[type=text]:focus, textarea:focus {
+    box-shadow: 0 0 5px rgba(240,122,82,1);
+    outline: 1px solid $pale-orange;
+    border: 1px solid rgba(240,122,82,1);
+  }
+}
+
+
+.results {
+  margin-top: 30px;
+  position: relative;
+
+  .add-spinner, .error {
+    width: 100%;
+    border-radius: 4px;
+    font-size: 13px;
+    padding: 10px;
+    font-family: 'Courier New', Courier, monospace;
+  }
+
+  .add-spinner {
+    background-color: $light-light-orange;
+    border: 1px solid $pale-orange;
+  }
+
+  .error {
+    background-color: $red-fail;
+    border: 1px solid $red-fail-border;
+  }
+
+  .loaded {
+    display: none;
+  }
+}
+
+.placeholder {
+  margin-top: 30px;
+  font-family: ‘Courier New’, Courier, monospace;
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,3 +1,35 @@
-<div class="container">
-  {{outlet}}
+<div class="wrapper">
+  <div class="welcome">
+    <div class="container">
+      <h2>Emblem Preview</h2>
+      <h4>
+        an Emblem parser preview
+      </h4>
+      <a href="https://github.com/bantic/emblem-preview"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>
+    </div>
+  </div>
+
+  <div class='emblem-preview'>
+    <div class="container">
+      {{outlet}}
+    </div>
+  </div>
+
+  <div class="footer">
+    <div class="container">
+      <div class="row">
+        <a href="https://github.com/machty/emblem.js">
+          Emblem Source
+        </a>
+        |
+        <a href="https://github.com/bantic/emblem-preview-api">
+          Emblem Preview API Source
+        </a>
+        |
+        <a href="https://github.com/bantic/emblem-preview">
+          Emblem Preview Source
+        </a>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,26 +1,38 @@
 <div class="row">
   <div class="col-md-6">
-    {{textarea value=emblem class="large"}}
+    <div class="input">
+      {{textarea value=emblem class="large"}}
+    </div>
   </div>
 
   <div class="col-md-6">
-    {{#emblem-preview emblem=emblem as |compiled loading error|}}
-    {{#if loading}}
-      Loading...
-    {{/if}}
+      {{#emblem-preview emblem=emblem as |compiled loading error|}}
 
-    {{#if compiled}}
-    <pre>
-      {{compiled}}
-    </pre>
-    {{/if}}
+        {{#if emblem}}
+          <div {{bind-attr class=":results error:error"}}>
+            <div {{bind-attr class="loading:add-spinner:loaded"}}>
+              Loading...
+            </div>
 
-    {{#if error}}
-    <div class="error">
-      ERROR: {{error}}
+            {{#if compiled}}
+              <pre>
+                {{compiled}}
+              </pre>
+            {{/if}}
+
+            {{#if error}}
+              <div class="error">
+                ERROR: {{error}}
+              </div>
+            {{/if}}
+          </div>
+
+        {{else}}
+          <div class='placeholder'>
+            <h3>A little Ember app to allow a live preview of Emblem code.</h3>
+          </div>
+        {{/if}}
+      {{/emblem-preview}}
     </div>
-    {{/if}}
-    {{/emblem-preview}}
-  </div>
 </div>
 


### PR DESCRIPTION
@bantic This PR takes a pass at styling the Ember Preview app, adding colors to signify different states, links to the various repos, a Github ribbon for forking, and a responsive column design. 

![screen shot 2015-03-02 at 5 08 13 pm](https://cloud.githubusercontent.com/assets/545972/6454548/44f35f9e-c0ff-11e4-88c7-9bc79ab5ba99.png)
